### PR TITLE
Fix: release workflow and version number

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
This pull request fixes the release workflow and version number. It includes the following commits:

- bugfix: Add response compression and update response classes

- fix: Update release workflow and version number

- fix: Update release workflow and version number

- fix: Update release-drafter configuration and version.json

- fix: Update release-drafter configuration and version.json

- fix: Update release workflow and version number

- Merge branch 'v1.17.0' of https://github.com/GreatIdeasGH/EducareHigh into v1.17.0