### PR TITLE
fix: Update version to 2.2.x in version.json

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,10 +1,7 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.3-alpha",
+  "version": "2.2.x",
   "assemblyVersion": {
     "precision": "revision"
   },
-  "publicReleaseRefSpec": [
-    "^refs/heads/v\\d+\\.\\d+$"
-  ]
+  "publicReleaseRefSpec": ["^refs/heads/v\\d+\\.\\d+$"]
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,6 @@
 {
-  "version": "2.2.x",
+  "version": "2.2",
+  "buildNumberOffset": 0,
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
This pull request updates the version in the version.json file to 2.2.x and also updates the build number offset.